### PR TITLE
CHG: Fixes for first light image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,8 @@ $(LB)/MModuleDepthCalibrationB.o\
 $(LB)/MGUIOptionsDepthCalibrationB.o\
 $(LB)/MGUIOptionsResponseGenerator.o\
 $(LB)/MModuleResponseGenerator.o\
+$(LB)/MModuleDiagnostics.o\
+$(LB)/MGUIExpoDiagnostics.o\
 
 
 

--- a/include/MAssembly.h
+++ b/include/MAssembly.h
@@ -69,8 +69,9 @@ class MAssembly
   static const uint64_t c_PositionDetermiation     = (1 << 18);
   static const uint64_t c_Statistics               = (1 << 19);
   static const uint64_t c_FlagHits                 = (1 << 20);
-  static const uint64_t c_ResponseGeneration       = (1 << 21);
-  
+  static const uint64_t c_Diagnostics              = (1 << 21);
+  static const uint64_t c_ResponseGeneration       = (1 << 22);
+
   // IMPORTANT:
   // If you add one analysis level, make sure you also handle it in:
   // -> ALL module constructors!

--- a/include/MGUIExpoDiagnostics.h
+++ b/include/MGUIExpoDiagnostics.h
@@ -1,0 +1,102 @@
+/*
+ * MGUIExpoDiagnostics.h
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MGUIExpoDiagnostics__
+#define __MGUIExpoDiagnostics__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// ROOT libs:
+#include <TROOT.h>
+#include <TVirtualX.h>
+#include <TGWindow.h>
+#include <TObjArray.h>
+#include <TGFrame.h>
+#include <TGButton.h>
+#include <TString.h>
+#include <TGClient.h>
+#include <TRootEmbeddedCanvas.h>
+#include <TH1.h>
+#include <TH2.h>
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MGUIERBList.h"
+
+// Nuclearizer libs
+#include "MGUIExpo.h"
+#include "MStripHit.h"
+
+// Forward declarations:
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class MGUIExpoDiagnostics : public MGUIExpo
+{
+  // public Session:
+ public:
+  //! Default constructor
+  MGUIExpoDiagnostics(MModule* Module);
+  //! Default destructor
+  virtual ~MGUIExpoDiagnostics();
+
+  //! The creation part which gets overwritten
+  virtual void Create();
+
+  //! Update the frame
+  virtual void Update();
+
+  //! Reset the data in the UI
+  virtual void Reset();
+
+  //! Export the data in the UI
+  virtual void Export(const MString& FileName);
+
+  //! Set the energy histogram parameters 
+  void SetStripHitHistogramParameters(int NBinsIDs, double MinIDs, double MaxIDs, int NBinsEnergy, double MinEnergy, double MaxEnergy);
+
+  //! Add strip data
+  void AddStripHit(MStripHit* SH);
+
+
+  // protected methods:
+ protected:
+
+
+  // protected members:
+ protected:
+
+  // private members:
+ private:
+  //! Energy canvas
+  TRootEmbeddedCanvas* m_DiagnosticsCanvas;
+  //! Low-voltage strip hit histogram
+  TH2D* m_StripHitsLV;
+  //! High-voltage strip hit histogram
+  TH2D* m_StripHitsHV;
+
+
+
+#ifdef ___CLING___
+ public:
+  ClassDef(MGUIExpoDiagnostics, 1) // basic class for dialog windows
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/include/MModuleDiagnostics.h
+++ b/include/MModuleDiagnostics.h
@@ -1,0 +1,89 @@
+/*
+ * MModuleDiagnostics.h
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MModuleDiagnostics__
+#define __MModuleDiagnostics__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Standard libs:
+#include <fstream>
+using namespace std;
+
+// ROOT libs:
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MString.h"
+#include "MFile.h"
+
+// Nuclearizer libs:
+#include "MModule.h"
+#include "MGUIExpoDiagnostics.h"
+
+// Forward declarations:
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class MModuleDiagnostics : public MModule
+{
+  // public interface:
+ public:
+  //! Default constructor
+  MModuleDiagnostics();
+  //! Default destructor
+  virtual ~MModuleDiagnostics();
+  
+  //! Create a new object of this class 
+  virtual MModuleDiagnostics* Clone() { return new MModuleDiagnostics(); }
+
+  //! Create the expos
+  virtual void CreateExpos();
+
+  //! Initialize the module
+  virtual bool Initialize();
+
+  //! Finalize the module
+  virtual void Finalize();
+
+  //! Main data analysis routine, which updates the event to a new level 
+  virtual bool AnalyzeEvent(MReadOutAssembly* Event);
+  
+  // protected methods:
+ protected:
+  
+  // private methods:
+ private:
+
+  // protected members:
+ protected:
+  //! The display of debugging data
+  MGUIExpoDiagnostics* m_ExpoDiagnostics;
+
+  // private members:
+ private:
+
+  
+#ifdef ___CLING___
+ public:
+  ClassDef(MModuleDiagnostics, 0) // no description
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/include/MModuleStripPairingGreedy.h
+++ b/include/MModuleStripPairingGreedy.h
@@ -228,6 +228,9 @@ class MModuleStripPairingGreedy : public MModule
   //! The display of debugging data
   MGUIExpoStripPairing* m_ExpoStripPairing;
  
+  //! Need a global strip pairing failed flag
+  MString m_StripPairingFailed;
+
   int m_TotalMatches; //Event Counters 
   int m_NMatches; //Variable Match counter, used to events with a specific numbers of strips involved 
   int m_NBadMatches; //Counts the number of badly matched events

--- a/include/MStripHit.h
+++ b/include/MStripHit.h
@@ -26,6 +26,7 @@
 // Nuclearizer libs
 #include "MReadOutElement.h"
 #include "MReadOutElementDoubleStrip.h"
+#include "MStripHit.h"
 
 // Forward declarations:
 

--- a/src/MAssembly.cxx
+++ b/src/MAssembly.cxx
@@ -73,6 +73,7 @@ using namespace std;
 #include "MModuleEventFilter.h"
 #include "MModuleEventSaver.h"
 #include "MModuleResponseGenerator.h"
+#include "MModuleDiagnostics.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -126,6 +127,8 @@ MAssembly::MAssembly()
   m_Supervisor->AddAvailableModule(new MModuleEventSaver());
   m_Supervisor->AddAvailableModule(new MModuleTransmitterRealta());
   m_Supervisor->AddAvailableModule(new MModuleResponseGenerator());
+
+  m_Supervisor->AddAvailableModule(new MModuleDiagnostics());
 
   m_Supervisor->Load();
   

--- a/src/MGUIExpoDiagnostics.cxx
+++ b/src/MGUIExpoDiagnostics.cxx
@@ -1,0 +1,204 @@
+/*
+ * MGUIExpoDiagnostics.cxx
+ *
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Andreas Zoglauer.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+
+// Include the header:
+#include "MGUIExpoDiagnostics.h"
+
+// Standard libs:
+
+// ROOT libs:
+#include <TSystem.h>
+#include <TString.h>
+#include <TGLabel.h>
+#include <TGResourcePool.h>
+#include <TCanvas.h>
+
+// MEGAlib libs:
+#include "MStreams.h"
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifdef ___CLING___
+ClassImp(MGUIExpoDiagnostics)
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIExpoDiagnostics::MGUIExpoDiagnostics(MModule* Module) : MGUIExpo(Module)
+{
+  // standard constructor
+
+  // Set the new title of the tab here:
+  m_TabTitle = "Dignostics";
+
+  // Add all histograms and canvases below
+  m_StripHitsLV = new TH2D("", "Diagnostics: Strip Hits LV - counts vs energy", 64, -0.5, 63.5, 100, 0, 2000);
+  m_StripHitsLV->SetXTitle("Strip ID");
+  m_StripHitsLV->SetYTitle("Energy [keV]");
+  m_StripHitsLV->SetZTitle("counts");
+  m_StripHitsLV->SetFillColor(kAzure+7);
+
+  m_StripHitsHV = new TH2D("", "Diagnostics: Strip Hits HV - counts vs energy", 64, -0.5, 63.5, 100, 0, 2000);
+  m_StripHitsHV->SetXTitle("Strip ID");
+  m_StripHitsLV->SetYTitle("Energy [keV]");
+  m_StripHitsHV->SetZTitle("counts");
+  m_StripHitsHV->SetFillColor(kAzure+7);
+
+  m_DiagnosticsCanvas = nullptr;
+
+  // use hierarchical cleaning
+  SetCleanup(kDeepCleanup);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIExpoDiagnostics::~MGUIExpoDiagnostics()
+{
+  // kDeepCleanup is activated 
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoDiagnostics::Reset()
+{
+  //! Reset the data in the UI
+
+  m_Mutex.Lock();
+  
+  m_StripHitsLV->Reset();
+  m_StripHitsHV->Reset();
+
+  m_Mutex.UnLock();
+}
+  
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoDiagnostics::SetStripHitHistogramParameters(int NBinsIDs, double MinIDs, double MaxIDs, int NBinsEnergy, double MinEnergy, double MaxEnergy)
+{
+  // Set the energy histogram parameters 
+
+  m_Mutex.Lock();
+  
+  m_StripHitsLV->SetBins(NBinsIDs, MinIDs, MaxIDs, NBinsEnergy, MinEnergy, MaxEnergy);
+  m_StripHitsHV->SetBins(NBinsIDs, MinIDs, MaxIDs, NBinsEnergy, MinEnergy, MaxEnergy);
+
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoDiagnostics::AddStripHit(MStripHit* SH)
+{
+  // Add data to the energy histogram
+
+  m_Mutex.Lock();
+
+  // TODO: Should be LV / HV - old version?
+  if (SH->IsXStrip() == true) {
+    m_StripHitsLV->Fill(SH->GetStripID(), SH->GetEnergy());
+  } else {
+    m_StripHitsHV->Fill(SH->GetStripID(), SH->GetEnergy());
+  }
+
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoDiagnostics::Create()
+{
+  // Add the GUI options here
+  
+  // Do not create it twice!
+  if (m_IsCreated == true) return;
+  
+  m_Mutex.Lock();
+
+  TGLayoutHints* CanvasLayout = new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX | kLHintsExpandY,
+                                                  2, 2, 2, 2);
+
+  TGHorizontalFrame* HFrame = new TGHorizontalFrame(this);
+  AddFrame(HFrame, CanvasLayout);
+
+  
+  m_DiagnosticsCanvas = new TRootEmbeddedCanvas("Energies", HFrame, 100, 100);
+  HFrame->AddFrame(m_DiagnosticsCanvas, CanvasLayout);
+  m_DiagnosticsCanvas->GetCanvas();
+  m_DiagnosticsCanvas->GetCanvas()->Divide(2,1);
+  m_DiagnosticsCanvas->GetCanvas()->cd(1);
+  m_StripHitsLV->Draw("colz");
+  m_DiagnosticsCanvas->GetCanvas()->cd(2);
+  m_StripHitsHV->Draw("colz");
+  m_DiagnosticsCanvas->GetCanvas()->Update();
+  
+  m_IsCreated = true;
+  
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoDiagnostics::Update()
+{
+  //! Update the frame
+
+  m_Mutex.Lock();
+  
+  if (m_DiagnosticsCanvas != nullptr) {
+    m_DiagnosticsCanvas->GetCanvas()->Modified();
+    m_DiagnosticsCanvas->GetCanvas()->Update();
+  }
+  
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoDiagnostics::Export(const MString& FileName)
+{
+  // Add data to the energy histogram
+
+  m_Mutex.Lock();
+  
+  m_DiagnosticsCanvas->GetCanvas()->SaveAs(FileName);
+  
+  m_Mutex.UnLock();
+}
+
+
+// MGUIExpoDiagnostics: the end...
+////////////////////////////////////////////////////////////////////////////////

--- a/src/MModuleDiagnostics.cxx
+++ b/src/MModuleDiagnostics.cxx
@@ -1,0 +1,146 @@
+/*
+ * MModuleDiagnostics.cxx
+ *
+ *
+ * Copyright (C) by Andreas Zoglauer
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Andreas Zoglauer.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// MModuleDiagnostics
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Include the header:
+#include "MModuleDiagnostics.h"
+
+// Standard libs:
+
+// ROOT libs:
+
+// MEGAlib libs:
+#include "MTime.h"
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifdef ___CLING___
+ClassImp(MModuleDiagnostics)
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MModuleDiagnostics::MModuleDiagnostics() : MModule()
+{
+  // Construct an instance of MModuleTemplate
+
+  // Set all module relevant information
+
+  // Set the module name --- has to be unique
+  m_Name = "Diagnostics (can be run at any spot after reading)";
+
+  // Set the XML tag --- has to be unique --- no spaces allowed
+  m_XmlTag = "XmlTagDiagnostics";
+
+  // Set all modules, which have to be done before this module
+  AddPreceedingModuleType(MAssembly::c_EventLoader);
+  
+  // Set all types this modules handles
+  AddModuleType(MAssembly::c_Diagnostics);
+
+  // Set all modules, which can follow this module
+  AddSucceedingModuleType(MAssembly::c_NoRestriction);
+  
+  // Set if this module has an options GUI
+  m_HasOptionsGUI = false;
+
+  // Allow the use of multiple threads and instances
+  m_AllowMultiThreading = true;
+  m_AllowMultipleInstances = false;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MModuleDiagnostics::~MModuleDiagnostics()
+{
+  // Destructor
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MModuleDiagnostics::CreateExpos()
+{
+  // Create all expos
+
+  if (HasExpos() == true) return;
+
+  // Set the histogram display
+  m_ExpoDiagnostics = new MGUIExpoDiagnostics(this);
+  m_ExpoDiagnostics->SetStripHitHistogramParameters(64, -0.5, 63.5, 200, 0, 2000);
+  m_Expos.push_back(m_ExpoDiagnostics);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MModuleDiagnostics::Initialize()
+{
+  // Initialize the module - nothing to be done
+  
+  return MModule::Initialize();
+}
+
+  
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MModuleDiagnostics::Finalize()
+{
+  // Finalize the module - nothing to be done
+
+  MModule::Finalize();
+  
+  return;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MModuleDiagnostics::AnalyzeEvent(MReadOutAssembly* Event)
+{
+  // Write the event to disk
+ 
+  if (HasExpos() == true) {
+    for (unsigned int sh = 0; sh < Event->GetNStripHits(); ++sh) {
+      m_ExpoDiagnostics->AddStripHit(Event->GetStripHit(sh));
+    }
+  }
+
+  return true;
+}
+
+
+// MModuleDiagnostics.cxx: the end...
+////////////////////////////////////////////////////////////////////////////////

--- a/src/MModuleStripPairingGreedy.cxx
+++ b/src/MModuleStripPairingGreedy.cxx
@@ -34,6 +34,7 @@
 // MEGAlib libs:
 //#include "MMath.h"
 #include "MGUIOptionsStripPairing.h"
+#include <malloc/_malloc_type.h>
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -396,7 +397,7 @@ bool MModuleStripPairingGreedy::AnalyzeEvent(MReadOutAssembly* Event){
 
     if (Difference > 2*pUncertainty + 2*nUncertainty + 20) {
 			if (Event->GetHit(h)->GetStripHitMultipleTimesX() == false && Event->GetHit(h)->GetStripHitMultipleTimesY() == false){
-		  	Event->SetStripPairingIncomplete(true,"bad pairing");
+		  	Event->SetStripPairingIncomplete(true, "bad pairing");
 			}
 /*			if (nHits[0] != 0 && nHits[1] != 0){
 				PrintXYStripsHitOrig();
@@ -458,6 +459,10 @@ bool MModuleStripPairingGreedy::AnalyzeEvent(MReadOutAssembly* Event){
 		dummy_func();
 	}
 */
+
+  if (m_StripPairingFailed != "") {
+    Event->SetStripPairingIncomplete(true, m_StripPairingFailed);
+  }
 
   Event->SetAnalysisProgress(MAssembly::c_StripPairing);
   /*
@@ -658,6 +663,9 @@ void MModuleStripPairingGreedy::WriteHits(MReadOutAssembly* Event, int detector)
 
 
 	vector<vector<vector<int> > > decodedFinalPairs = DecodeFinalPairs();
+
+  if (m_StripPairingFailed != "") return;
+
 
 	//pair indexes over the pairs (hits) -- for each pair, there is a new MHit
 	//strip indexes over the strips in each pair on the x or y side
@@ -1892,6 +1900,11 @@ vector<vector<vector<int> > > MModuleStripPairingGreedy::DecodeFinalPairs(){
 			//vector<float>::iterator itTwo = energyResolution.begin();
 			//vector<float>::iterator itThree = hitQualityFactor.begin();
 
+      if (hitEnergy.size() <= i+twoHitsCounter-1) {
+        m_StripPairingFailed = "Programming error: Array out of bounds";
+        cout<<m_StripPairingFailed<<endl;
+        return decodedFinalPairs;
+      }
 			hitEnergy.at(i+twoHitsCounter-1) = energyOne;
 			hitEnergy.insert(hitEnergy.begin()+i+twoHitsCounter, energyTwo);
 			energyResolution.at(i+twoHitsCounter-1) = eResOne;
@@ -1946,6 +1959,12 @@ vector<vector<vector<int> > > MModuleStripPairingGreedy::DecodeFinalPairs(){
 			//vector<float>::iterator itOne = hitEnergy.begin();
 			//vector<float>::iterator itTwo = energyResolution.begin();
 			//vector<float>::iterator itThree = hitQualityFactor.begin();
+
+      if (hitEnergy.size() <= i+twoHitsCounter-1) {
+        m_StripPairingFailed = "Programming error: Array out of bounds";
+        cout<<m_StripPairingFailed<<endl;
+        return decodedFinalPairs;
+      }
 
 			hitEnergy.at(i+twoHitsCounter-1) = energyOne;
 			hitEnergy.insert(hitEnergy.begin()+i+twoHitsCounter, energyTwo);
@@ -2017,6 +2036,12 @@ vector<vector<vector<int> > > MModuleStripPairingGreedy::DecodeFinalPairs(){
 			//vector<float>::iterator itOne = hitEnergy.begin();
 			//vector<float>::iterator itTwo = energyResolution.begin();
 			//vector<float>::iterator itThree = hitQualityFactor.begin();
+
+      if (hitEnergy.size() <= i+threeHitsCounter-1) {
+        m_StripPairingFailed = "Programming error: Array out of bounds";
+        cout<<m_StripPairingFailed<<endl;
+        return decodedFinalPairs;
+      }
 
 			hitEnergy.at(i+threeHitsCounter-1) = energyOne;
 			hitEnergy.insert(hitEnergy.begin()+i+threeHitsCounter, energyTwo);
@@ -2090,6 +2115,12 @@ vector<vector<vector<int> > > MModuleStripPairingGreedy::DecodeFinalPairs(){
 			//vector<float>::iterator itTwo = energyResolution.begin();
 			//vector<float>::iterator itThree = hitQualityFactor.begin();
 
+      if (hitEnergy.size() <= i+threeHitsCounter-1) {
+        m_StripPairingFailed = "Programming error: Array out of bounds";
+        cout<<m_StripPairingFailed<<endl;
+        return decodedFinalPairs;
+      }
+
 			hitEnergy.at(i+threeHitsCounter-1) = energyOne;
 			hitEnergy.insert(hitEnergy.begin()+i+threeHitsCounter, energyTwo);
 			hitEnergy.insert(hitEnergy.begin()+i+threeHitsCounter+1, energyThree);
@@ -2154,6 +2185,9 @@ vector<vector<vector<int> > > MModuleStripPairingGreedy::DecodeFinalPairs(){
 bool MModuleStripPairingGreedy::CheckAllStripsWerePaired(){
   
   vector<vector<vector<int> > > decodedFinalPairs = DecodeFinalPairs();
+
+  if (m_StripPairingFailed != "") return false;
+
   int counter = 0;
   
   //count how many strips in decodedFinalPairs are equal to original strips


### PR DESCRIPTION
Added diagnostics module showing the strip vs energy distribution.
Protected against a buffer overflow in the strip pairing module, by flagging those events as bad.